### PR TITLE
fix_version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     
     setuptools.setup(
         name="cron_descriptor",
-        version="1.2.24+se-1",
+        version="1.2.24-se-1",
         description="A Python library that converts cron expressions "
                     "into human readable strings.",
         author="Adam Schubert",


### PR DESCRIPTION

Why this is needed

While installing this package we get the following error:
```
  Downloading https://pypi.seinternal.com:30443/packages/cron_descriptor-1.2.24-se-1.tar.gz (27 kB)
  Preparing metadata (setup.py) ... done
  WARNING: Requested cron-descriptor==1.2.24-se-1 from https://pypi.seinternal.com:30443/packages/cron_descriptor-1.2.24-se-1.tar.gz (from -r /home/spamexperts/update/apps-python3-requirements/requirements_unfrozen.txt (line 41)), but installing version 1.2.24+se.1
Discarding https://pypi.seinternal.com:30443/packages/cron_descriptor-1.2.24-se-1.tar.gz (from https://pypi.seinternal.com:30443/simple/cron-descriptor/): Requested cron-descriptor==1.2.24-se-1 from https://pypi.seinternal.com:30443/packages/cron_descriptor-1.2.24-se-1.tar.gz (from -r /home/spamexperts/update/apps-python3-requirements/requirements_unfrozen.txt (line 41)) has inconsistent version: filename has '1.2.24-se-1', but metadata has '1.2.24+se.1'
ERROR: Could not find a version that satisfies the requirement cron-descriptor==1.2.24-se-1 (from versions: 1.2.10-se, 1.2.10-se-1, 1.2.24-se-1, 1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.2.6, 1.2.7, 1.2.8, 1.2.9, 1.2.10, 1.2.16, 1.2.20, 1.2.21, 1.2.24)
ERROR: No matching distribution found for cron-descriptor==1.2.24-se-1
```

How we fix this:

Adjusted the version to match the name .
